### PR TITLE
fix: machine pool version field format

### DIFF
--- a/cloud/scope/managedmachinepool.go
+++ b/cloud/scope/managedmachinepool.go
@@ -151,7 +151,7 @@ func (s *ManagedMachinePoolScope) InstanceGroupManagersClient() *compute.Instanc
 
 // NodePoolVersion returns the k8s version of the node pool.
 func (s *ManagedMachinePoolScope) NodePoolVersion() *string {
-	return s.MachinePool.Spec.Template.Spec.Version
+	return infrav1exp.NormalizeMachineVersion(s.MachinePool.Spec.Template.Spec.Version)
 }
 
 // ConvertToSdkNodePool converts a node pool to format that is used by GCP SDK.
@@ -184,7 +184,7 @@ func ConvertToSdkNodePool(nodePool infrav1exp.GCPManagedMachinePool, machinePool
 	}
 
 	if machinePool.Spec.Template.Spec.Version != nil {
-		sdkNodePool.Version = *machinePool.Spec.Template.Spec.Version
+		sdkNodePool.Version = *infrav1exp.NormalizeMachineVersion(machinePool.Spec.Template.Spec.Version)
 	}
 
 	return &sdkNodePool

--- a/exp/api/v1beta1/types.go
+++ b/exp/api/v1beta1/types.go
@@ -79,7 +79,7 @@ func ConvertToSdkTaint(taints Taints) []*containerpb.NodeTaint {
 // - "1.X": picks the highest valid patch+gke.N patch in the 1.X version
 // - "1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version
 // - "1.X.Y-gke.N": picks an explicit Kubernetes version
-// - "-": picks the Kubernetes master version
+// - "-": picks the Kubernetes master version.
 func NormalizeMachineVersion(version *string) *string {
 	if version == nil {
 		return nil


### PR DESCRIPTION
This fixes an issue where CAPI core installs a mutating webhook that adds a `v` prefix to the machine pool version field. GKE expects a different format (without the `v` prefix).