### PR TITLE
feat: workload identity for kubeconfig credentials

### DIFF
--- a/cloud/scope/clients.go
+++ b/cloud/scope/clients.go
@@ -82,7 +82,7 @@ func defaultClientOptions(ctx context.Context, credentialsRef *infrav1.ObjectRef
 		if err != nil {
 			return nil, fmt.Errorf("getting gcp credentials from reference %s: %w", credentialsRef, err)
 		}
-		opts = append(opts, option.WithCredentialsJSON(rawData))
+		opts = append(opts, option.WithCredentialsJSON(rawData.JSON))
 	}
 
 	return opts, nil

--- a/cloud/scope/credentials.go
+++ b/cloud/scope/credentials.go
@@ -47,6 +47,7 @@ type Credential struct {
 	token oauth2.TokenSource
 }
 
+// GetToken returns the access token of the loaded GCP credentials.
 func (c *Credential) GetToken(ctx context.Context) (string, error) {
 	token, err := c.token.Token()
 	if err != nil {
@@ -56,19 +57,19 @@ func (c *Credential) GetToken(ctx context.Context) (string, error) {
 }
 
 func getCredentials(ctx context.Context, credentialsRef *infrav1.ObjectReference, crClient client.Client) (*Credential, error) {
-	var credentialData *google.Credentials
+	var credential *google.Credentials
 	var err error
 
 	if credentialsRef != nil {
-		credentialData, err = getCredentialDataFromRef(ctx, credentialsRef, crClient)
+		credential, err = getCredentialDataFromRef(ctx, credentialsRef, crClient)
 	} else {
-		credentialData, err = getCredentialDataUsingADC(ctx)
+		credential, err = getCredentialDataUsingADC(ctx)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting credential data: %w", err)
 	}
 
-	token := credentialData.TokenSource
+	token := credential.TokenSource
 	if token == nil {
 		return nil, errors.New("failed retrieving token from credentials")
 	}

--- a/cloud/services/container/clusters/kubeconfig.go
+++ b/cloud/services/container/clusters/kubeconfig.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/container/apiv1/containerpb"
-	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -147,7 +146,7 @@ func (s *Service) createCAPIKubeconfigSecret(ctx context.Context, cluster *conta
 		return fmt.Errorf("creating base kubeconfig: %w", err)
 	}
 
-	token, err := s.generateToken(ctx)
+	token, err := s.scope.GetCredential().GetToken(ctx)
 	if err != nil {
 		log.Error(err, "failed generating token")
 		return err
@@ -184,7 +183,7 @@ func (s *Service) updateCAPIKubeconfigSecret(ctx context.Context, configSecret *
 		return errors.Wrap(err, "failed to convert kubeconfig Secret into a clientcmdapi.Config")
 	}
 
-	token, err := s.generateToken(ctx)
+	token, err := s.scope.GetCredential().GetToken(ctx)
 	if err != nil {
 		return err
 	}
@@ -238,18 +237,4 @@ func (s *Service) createBaseKubeConfig(contextName string, cluster *containerpb.
 	}
 
 	return cfg, nil
-}
-
-func (s *Service) generateToken(ctx context.Context) (string, error) {
-	req := &credentialspb.GenerateAccessTokenRequest{
-		Name: fmt.Sprintf("projects/-/serviceAccounts/%s", s.scope.GetCredential().ClientEmail),
-		Scope: []string{
-			GkeScope,
-		},
-	}
-	resp, err := s.scope.CredentialsClient().GenerateAccessToken(ctx, req)
-	if err != nil {
-		return "", errors.Errorf("error generating access token: %v", err)
-	}
-	return resp.AccessToken, nil
 }

--- a/cloud/services/container/clusters/reconcile.go
+++ b/cloud/services/container/clusters/reconcile.go
@@ -263,6 +263,7 @@ func (s *Service) createCluster(ctx context.Context, log *logr.Logger) error {
 		WorkloadIdentityConfig: s.createWorkloadIdentityConfig(),
 		NetworkConfig:          s.createNetworkConfig(),
 		AddonsConfig:           s.createAddonsConfig(),
+		ResourceLabels:         s.scope.GCPManagedCluster.Labels,
 	}
 
 	if s.scope.GCPManagedControlPlane.Spec.ControlPlaneVersion != nil {


### PR DESCRIPTION
This should allow for using the workload identity for the credentials used in the KubeConfig so the controller can access the clusters it manages. When generating the token for the KubeConfig the only field that is used from the credentials is `ClientEmail`, which the `CredentialsClient()` then generates a token for. The `Type`, `ProjectID` and `ClientID` from the mounted credentials are not used.

Note: the credentials struct might need to `client_secret` and `refresh_token` fields to enable using the CLI generated `$HOME/.config/gcloud/application_default_credentials.json` file. The `generateToken()` function in `cloud/services/clusters/kubeconfig.go` would then need to be extended so it can create a token for the `type: authorized_user` along with the new fields.